### PR TITLE
Optimization of busy signal port sampling routine

### DIFF
--- a/HyperLoader/src/Main.asm
+++ b/HyperLoader/src/Main.asm
@@ -178,15 +178,15 @@ GetPulse:
 	;; Keep reading from cassette port until we get a low read
 waitWhileLow:
 	in	a, (c)
-	and	%01000000
-	jp	z, waitWhileLow
+	rla
+	jp	m, waitWhileLow
 
 	;; And how count how many times we get a high bit
 waitWhileHigh:
 	inc	c			
 	in	a, (c)
-	and	%01000000
-	jp	nz, waitWhileHigh
+	rla
+	jp	p, waitWhileHigh
 	ld	a, c
 	ret
  ENDIF

--- a/HyperLoader/src/Main.asm
+++ b/HyperLoader/src/Main.asm
@@ -178,14 +178,14 @@ GetPulse:
 	;; Keep reading from cassette port until we get a low read
 waitWhileLow:
 	in	a, (c)
-	rla
+	add	a, a
 	jp	m, waitWhileLow
 
 	;; And how count how many times we get a high bit
 waitWhileHigh:
 	inc	c			
 	in	a, (c)
-	rla
+	add	a, a
 	jp	p, waitWhileHigh
 	ld	a, c
 	ret


### PR DESCRIPTION
It's slightly quicker and smaller to rotate A and use the sign condition than to bitmask A